### PR TITLE
Simplify dependencies, remove NETStandard.Library

### DIFF
--- a/src/JitterMagic/project.json
+++ b/src/JitterMagic/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.2-*",
+  "version": "1.1.3-*",
   "description": "A c# library to add jitter to cache durations and retry intervals to increase entropy in your system and prevent thundering herds",
 
   "packOptions": {
@@ -23,12 +23,8 @@
   "frameworks": {
     "netstandard1.0": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
-      }
-    },
-    "netcoreapp1.0": {
-      "dependencies": {
-        "Microsoft.NETCore.App": "1.0.0"
+        "System.Runtime": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0"
       }
     },
     "net20": {},


### PR DESCRIPTION
Removed `netcoreapp` entirely, that's not needed if we're developing a library, since apps targeting `netcoreapp1.0` are able to reference `netstandard` libraries.